### PR TITLE
i18n: german translation

### DIFF
--- a/locales/de.lua
+++ b/locales/de.lua
@@ -1,0 +1,15 @@
+Locale = Locale or {}
+
+Locale['de'] = { -- 'de' is the reference that will be used for 'Config.Language'
+	StandaloneLapText			= "Nach einem Lapdance fragen", 
+	LapText						= "Lapdance kaufen (~g~%$~w~)", 
+	BoughtLapdance				= "Du hast gerade einen Lapdance für %$ gekauft", 
+	StripperActive				= "Die Tänzerin ist bereits beschäftigt!", 
+	NotEnoughMoney				= "Du hast nicht genug Geld. Ein Lapdance kostet %$", 
+	AllPlacesTaken				= "Alle Plätze sind bereits belegt", 
+	lapStopped					= "Dein Lapdance wurde unterbrochen", 
+	Lean						= "Anlehnen", 
+	StandaloneLeanNotice		= "Drücke ~INPUT_CONTEXT~ um aufzustehen\nDrücke ~INPUT_JUMP~ um Geld zu werfen", 
+	LeanNotice					= "Drücke ~INPUT_CONTEXT~ um aufzustehen\nDrücke ~INPUT_JUMP~ um Geld zu werfen (~g~%$~w~)", 
+	NotEnoughCashLean			= "Nicht genug Bargeld zum Werfen vorhanden" 
+}

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -1,6 +1,6 @@
 Locale                          = Locale or {}
 
-Locale.en = { -- 'fr' is the reference that will be used for 'Config.Language'
+Locale.en = { -- 'en' is the reference that will be used for 'Config.Language'
 	StandaloneLapText			= "Ask for a lap dance", -- Set the text that will be displayed above marker if 'Config.Framework' is set to 'standalone'
 	LapText						= "Buy a lap dance (~g~%$~w~)", -- Set the text that will be displayed above marker
 	BoughtLapdance				= "You just bought a lap dance for %$", -- Notification text when a lap dance is bought


### PR DESCRIPTION
Adds German translation for kc-unicorn, also fixes a little mess up in the en.lua that was an inconsistency and was annoying the fuh out of me.